### PR TITLE
Build on FreeBSD 13-CURRENT amd64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ include_directories(imgui)
 include_directories(imgui/examples)
 include_directories(imgui/examples/libs/gl3w)
 include_directories(${SDL2_INCLUDE_DIRS})
+include_directories(${OPENGL_INCLUDE_DIR})
 
 add_library(Core STATIC
     common.cpp

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Dependencies:
 
  - **FFTW3** *(optional)* - some of the helper tools perform Fourier transformations [fftw](http://www.fftw.org)
 
-**Linux and Mac OS**
+**Linux, FreeBSD and Mac OS**
 
     git clone https://github.com/ggerganov/kbd-audio
     cd kbd-audio


### PR DESCRIPTION
Build under the following conditions:

```
[nico@sagittarius ~]$ uname -apKU
FreeBSD sagittarius.herrhotzenplotz.geek 13.0-CURRENT FreeBSD 13.0-CURRENT #1 r365694: Sun Sep 13 21:05:06 CEST 2020     nico@sagittarius.herrhotzenplotz.geek:/usr/obj/usr/src/amd64.amd64/sys/SAGITTARIUS  amd64 amd64 1300114 1300114
[nico@sagittarius ~]$ c++ --version
FreeBSD clang version 11.0.0 (git@github.com:llvm/llvm-project.git llvmorg-11.0.0-rc2-0-g414f32a9e86)
Target: x86_64-unknown-freebsd13.0
Thread model: posix
InstalledDir: /usr/bin
[nico@sagittarius ~]$ cmake --version
cmake version 3.18.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

As described in the commit message *BSD, other than GNU/Linux or macOS, stores the headers of thirdparty libraries in `/usr/local/include` for reasons of clear organization of the filesystem tree.

The build used to fail with: 
```
[ 27%] Building C object CMakeFiles/Gui.dir/imgui/examples/libs/gl3w/GL/gl3w.c.o
/home/nico/Source/kbd-audio/imgui/examples/libs/gl3w/GL/gl3w.c:67:10: fatal error: 'GL/glx.h' file not found
#include <GL/glx.h>
         ^~~~~~~~~~
1 error generated.
*** Error code 1

Stop.
make[2]: stopped in /usr/home/nico/Source/kbd-audio/build
*** Error code 1

Stop.
make[1]: stopped in /usr/home/nico/Source/kbd-audio/build
*** Error code 1

Stop.
make: stopped in /usr/home/nico/Source/kbd-audio/build
```

This is a hint, that the compiler flag `-I/usr/local/include` is missing. Fix is, to add the, possibly by accident forgotten `${OPENGL_INCLUDE_DIR}` in CMakeLists.txt.

I also added FreeBSD to the Readme, as I confirmed the succeeding build there. Chances are pretty high, that it will also build on other versions and branches.

Furthermore, everything appears to be working well. If you are interested, I may submit a patch for FreeBSD for commit to the official ports tree, such that this becomes officially available as a package that can be installed.

Thank you for the great work!